### PR TITLE
Resolve broken entrypoint and add test case

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,9 @@ EXPOSE 27005/udp
 EXPOSE 26900/udp
 EXPOSE 51840/udp
 
-WORKDIR /var/lib/steam/.steam/SteamApps/common/GarrysModDS/
+WORKDIR /var/lib/steam/.steam/steamapps/common/GarrysModDS/
 
-ENTRYPOINT ["/var/lib/steam/.steam/SteamApps/common/GarrysModDS/srcds_run"]
+ENTRYPOINT ["/var/lib/steam/.steam/steamapps/common/GarrysModDS/srcds_run"]
 CMD ["-game garrysmod", \
     "-maxplayers 16", \
     "+gamemode sandbox", \

--- a/README.md
+++ b/README.md
@@ -1,24 +1,28 @@
-# docker-garrysmodds [![CI](https://github.com/rbreslow/docker-garrysmodds/workflows/CI/badge.svg?branch=master)](https://github.com/rbreslow/docker-garrysmodds/actions?query=workflow%3ACI) [![Docker Repository on Quay](https://quay.io/repository/rbreslow/garrysmodds/status "Docker Repository on Quay")](https://quay.io/repository/rbreslow/garrysmodds)
+# docker-garrysmodds [![CI](https://github.com/rbreslow/docker-garrysmodds/workflows/CI/badge.svg?branch=master)](https://github.com/rbreslow/docker-garrysmodds/actions?query=workflow%3ACI)
 
 This repository contains a `Dockerfile` designed to support Garry's Mod Dedicated Server.
 
 ## Usage
 
-First, build the container image with:
+You can start Garry's Mod with the default launch options (16 max players, Sandbox, and `gm_flatgrass`) with the following:
 
-```bash
-docker build -t quay.io/rbreslow/garrysmodds:slim .
+```console
+$ docker run -it -p 27015:27015 -p 27015:27015/udp --rm quay.io/rbreslow/garrysmodds:slim
+
+. . .
+
+Connection to Steam servers successful.
+   Public IP is 1.1.1.1.
+Assigned anonymous gameserver Steam ID [A-1:0123456789(01234)].
+VAC secure mode is activated.
 ```
 
-Then, run the server and expose ports:
-
-```bash
-docker run -ti \
-    -p 27015:27015 \
-    -p 27015:27015/udp \
-    --rm quay.io/rbreslow/garrysmodds:slim
-```
+See [rbreslow/zs](https://github.com/rbreslow/zs) for an example that uses [Docker Compose](https://docs.docker.com/compose/).
 
 ## Testing
 
-TBD.
+An example of how to use `cibuild` to build and test an image:
+
+```console
+$ CI=1 ./scripts/cibuild
+```

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 set -e
-set -u
 
 if [[ -n "${CI}" ]]; then
     set -x
 fi
+
+set -u
 
 function usage() {
     echo -n \
@@ -20,6 +21,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     else
         docker \
             build -t "quay.io/rbreslow/garrysmodds:slim" .
+
+        ./scripts/test
 
         docker images
     fi

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 set -e
+
+if [[ -n "${CI}" ]]; then
+    set -x
+fi
+
 set -u
 
 function usage() {

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [[ -n "${CI}" ]]; then
+    set -x
+fi
+
+set -u
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Test container images.
+"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    if [[ "${1:-}" == "--help" ]]; then
+        usage
+    else
+        # Determine whether srcds_run is accessible by displaying the usage
+        # message.
+        docker run --rm \
+            quay.io/rbreslow/garrysmodds:slim -help
+
+        # srcds_run always kills itself with a SIGINT.
+        (( $? == 130 ))
+    fi
+fi


### PR DESCRIPTION
This pull request resolves an issue with the container image entry point where it appears that the `SteamApps` directory was renamed to `steamapps`:

```console
docker: Error response from daemon: OCI runtime create failed: container_linux.go:367: starting container process caused: exec: "/var/lib/steam/.steam/SteamApps/common/GarrysModDS/srcds_run": stat /var/lib/steam/.steam/SteamApps/common/GarrysModDS/srcds_run: no such file or directory: unknown.
```

Additionally, I added `scripts/test` to ensure that we won't run into a similar issue in the future and updated the README to reflect that we now have a test case.

---

**Testing**

See passing checks.

